### PR TITLE
fix styles hooks

### DIFF
--- a/preact.config.js
+++ b/preact.config.js
@@ -23,12 +23,5 @@ export default {
                 silent: true
             });
         });
-
-        // Use any `index` file, not just index.js
-        config.resolve.alias["preact-cli-entrypoint"] = resolve(
-            process.cwd(),
-            "src",
-            "index"
-        );
     }
 };

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -7,7 +7,7 @@ import Container from '@material-ui/core/Container';
 import GridListTile from '@material-ui/core/GridListTile';
 import GridListTileBar from '@material-ui/core/GridListTileBar';
 import Typography from '@material-ui/core/Typography';
-import useStyles, { DrawerStyles } from './styles';
+import { useAppStyles, useDrawerStyles } from './styles';
 import Drawer from "./drawer";
 
 interface ListItem { name: string; value: string; }
@@ -15,9 +15,6 @@ interface ColumnDetail { caption: string; entries?: Array<ListItem>; }
 
 export default
 class Application extends React.Component {
-	private classes = useStyles();
-	private drawer = DrawerStyles();
-
 	private state: object = {
 		shouldCollapse: false,
 		isNavbarOpened: false
@@ -54,28 +51,31 @@ class Application extends React.Component {
 	}
 
 	render() {
+		const classes = useAppStyles();
+		const drawerClasses = useAppStyles(); // doesn't seem to be used here
+
 		return (
-			<div className={this.classes.root}>
-				<AppBar color="primary" position="absolute" elevation={2} className={this.classes.mainAppBar.shell}>
+			<div className={classes.root}>
+				<AppBar color="primary" position="absolute" elevation={2} className={classes.mainAppBar.shell}>
 					<Toolbar variant="dense">
-						<Typography variant="h5" className={this.classes.appHeading} noWrap>
+						<Typography variant="h5" className={classes.appHeading} noWrap>
 						Hello, world!
 						</Typography>
 					</Toolbar>
 				</AppBar>
-				<AppBar elevation={0} color="secondary" position="fixed" className={this.classes.appBar}>
-					<Toolbar classes={{ root: this.classes.gridList }}>
-						<GridList className={this.classes.gridList} cellHeight={40} cols={this.columns.length}>{
+				<AppBar elevation={0} color="secondary" position="fixed" className={classes.appBar}>
+					<Toolbar classes={{ root: classes.gridList }}>
+						<GridList className={classes.gridList} cellHeight={40} cols={this.columns.length}>{
 							this.columns.map((column: ColumnDetail) => <GridListTile>{column.entries?
-									<GridListTileBar title={column.caption} subtitle={<span>Test</span>} classes={{ root: this.classes.gridItems }} />:
-									<GridListTileBar title={<Typography variant="h6">{column.caption}</Typography>} classes={{ root: this.classes.gridItems }} />
+									<GridListTileBar title={column.caption} subtitle={<span>Test</span>} classes={{ root: classes.gridItems }} />:
+									<GridListTileBar title={<Typography variant="h6">{column.caption}</Typography>} classes={{ root: classes.gridItems }} />
 								}</GridListTile>)
 						}</GridList>
 					</Toolbar>
 				</AppBar>
 				<Drawer />
-				<main className={this.classes.main}>
-					<Container className={this.classes.content} maxWidth="xl">
+				<main className={classes.main}>
+					<Container className={classes.content} maxWidth="xl">
 						<Typography align="justify" paragraph>
 							Lorem ipsum dolor sit amet, consectetur adipiscing elit,  sed do eiusmod  tempor incididunt ut
 							labore et dolore magna aliqua.  Rhoncus dolor  purus non enim praesent elementum facilisis leo

--- a/src/components/drawer/index.tsx
+++ b/src/components/drawer/index.tsx
@@ -18,46 +18,43 @@ import MenuIcon from '@material-ui/icons/Menu';
 import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
 import InboxIcon from '@material-ui/icons/MoveToInbox';
-import { DrawerStyles } from '../styles';
+import { useDrawerStyles } from '../styles';
 
-export default
-class NavDrawer extends React.Component {
-	private classes = DrawerStyles();
-
-	render({ open, shouldCollapse = false }) {
-		return (
-			<Drawer className={this.classes.drawer}
-					variant="permanent"
-					classes={{
-						paper: this.classes.paper
-					}}>
-				<Toolbar component="header" color="primary" variant="dense">
-					<Typography variant="h6" noWrap>
-						Clipped drawer
-					</Typography>
-				</Toolbar>
-				<main className={this.classes.drawerContainer}>
-					<List>{
-						["Inbox", "Starred", "Send email", "Drafts"].map((text, index) =>
-						(<ListItem button key={text}>
-							<ListItemIcon>
-								{index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-							</ListItemIcon>
-							<ListItemText primary={text} />
-						</ListItem>))
-					}</List>
-					<Divider />
-					<List>
-						{["All mail", "Trash", "Spam"].map((text, index) => (
-						<ListItem button key={text}>
-							<ListItemIcon>
+export default function NavDrawer({ open, shouldCollapse = false }) {
+	const classes = useDrawerStyles();
+	return (
+		<Drawer className={classes.drawer}
+				variant="permanent"
+				classes={{
+					paper: classes.paper
+				}}>
+			<Toolbar component="header" color="primary" variant="dense">
+				<Typography variant="h6" noWrap>
+					Clipped drawer
+				</Typography>
+			</Toolbar>
+			<main className={classes.drawerContainer}>
+				<List>{
+					["Inbox", "Starred", "Send email", "Drafts"].map((text, index) =>
+					(<ListItem button key={text}>
+						<ListItemIcon>
 							{index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-							</ListItemIcon>
-							<ListItemText primary={text} />
-						</ListItem>
-						))}
-					</List>
-				</main>
-			</Drawer>);
-	}
+						</ListItemIcon>
+						<ListItemText primary={text} />
+					</ListItem>))
+				}</List>
+				<Divider />
+				<List>
+					{["All mail", "Trash", "Spam"].map((text, index) => (
+					<ListItem button key={text}>
+						<ListItemIcon>
+						{index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+						</ListItemIcon>
+						<ListItemText primary={text} />
+					</ListItem>
+					))}
+				</List>
+			</main>
+		</Drawer>
+	);
 }

--- a/src/components/styles.ts
+++ b/src/components/styles.ts
@@ -4,7 +4,7 @@ export const drawerWidth: number = 248;
 export const appBarHeight: number  = 50;
 export const scaleFactor: number = 1.05;
 
-export default makeStyles((theme: Theme) => createStyles({
+export const useAppStyles = makeStyles((theme: Theme) => createStyles({
 	root: {
 		display: 'flex',
 		overflowY: 'inherit',
@@ -87,7 +87,7 @@ export default makeStyles((theme: Theme) => createStyles({
 	}
 }));
 
-export const DrawerStyles =
+export const useDrawerStyles =
 	makeStyles((theme: Theme) => createStyles({
 		drawer: {
 			width: drawerWidth,


### PR DESCRIPTION
[makeStyles](https://material-ui.com/styles/api/#makestyles-styles-options-hook) returns a hook, which should always be named like `useX` and can only be called from within functional components. Technically Preact also allows calling hooks within `render()`, which I've abused here to avoid turning your App class into a function. Can't say that will work forever though.